### PR TITLE
Add semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx -y semantic-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For more detailed information on each component, please refer to the respective 
 ## TODOs
 
 - [ ] Add swagger
-- [ ] add versioning
+- [x] add versioning
 - [ ] Add tests
 - [x] logger
 - [x] graceful shutdown

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  branches: ['main'],
+  tagFormat: 'v${version}',
+  plugins: [
+    ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
+    '@semantic-release/release-notes-generator',
+    ['@semantic-release/changelog', { changelogFile: 'CHANGELOG.md' }],
+    ['@semantic-release/exec', {
+      prepareCmd: 'scripts/set_version.sh ${nextRelease.version}'
+    }],
+    ['@semantic-release/git', {
+      assets: ['CHANGELOG.md', 'version.txt'],
+      message: 'chore(release): v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
+    }],
+    '@semantic-release/github'
+  ]
+};

--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Overwrite version.txt with the provided version number.
+# Usage: set_version.sh <version>
+
+version="$1"
+
+if [[ -z "$version" ]]; then
+  echo "Version is required" >&2
+  exit 1
+fi
+
+echo "$version" > version.txt


### PR DESCRIPTION
## Summary
- set up semantic-release GitHub workflow for automated versioning
- configure release process in `release.config.js`
- add helper script to update version file
- initialize `CHANGELOG.md`
- mark versioning as complete in README

## Testing
- `go test ./...` *(fails: missing method Shutdown in dummyAppTracer)*

------
https://chatgpt.com/codex/tasks/task_e_6872f68a399c8333b0cd5c140484b54f