### PR TITLE
Fix tests and expand coverage

### DIFF
--- a/app/cache/cache.go
+++ b/app/cache/cache.go
@@ -65,14 +65,19 @@ func (rc *redisCache) Get(serviceName string, ctx context.Context, key string) (
 		ResponseTime: time.Since(startTime),
 		Key:          key,
 		Error:        err,
-		Hit:          val != "",
+		Hit:          err == nil,
 	}
 	clientContext.AddCacheCall(ctx, newCacheCall)
-	if err != nil && err != redis.Nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return "", MapCacheError(&err)
+
+	if err != nil {
+		mappedErr := MapCacheError(&err)
+		if err != redis.Nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		return "", mappedErr
 	}
+
 	span.SetStatus(codes.Ok, "")
 
 	span.SetAttributes(attribute.String("cache.name", "redis"))

--- a/app/cache/cache_test.go
+++ b/app/cache/cache_test.go
@@ -69,7 +69,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestSet(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mr, cacher := setupTestRedis(t)
 	defer mr.Close()
 

--- a/example/features/albums/init_test.go
+++ b/example/features/albums/init_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jphilipstevens/web-service-gin/app/db"
 	"github.com/jphilipstevens/web-service-gin/app/dependencies"
+	"github.com/jphilipstevens/web-service-gin/testUtils"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
@@ -37,14 +37,14 @@ func TestInit(t *testing.T) {
 		}
 		defer client.Close()
 
-		database := db.Database{Client: client}
+		database := testUtils.NewDatabase(client)
 
 		mockCache := new(MockCache)
 
 		router := gin.Default()
 
 		deps := &dependencies.Dependencies{
-			DB:     &database,
+			DB:     database,
 			Cache:  mockCache,
 			Router: router,
 		}

--- a/example/features/albums/repository_test.go
+++ b/example/features/albums/repository_test.go
@@ -22,7 +22,7 @@ func TestNewAlbumRepository(t *testing.T) {
 }
 
 func TestGetAlbumsRepository(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 
 	t.Run("Get all albums", func(t *testing.T) {
 		mockDB, mock, _ := sqlmock.New()
@@ -82,7 +82,7 @@ func TestGetAlbumsRepository(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, mock, _ := sqlmock.New()
 	defer mockDB.Close()
 
@@ -99,7 +99,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestInsertBatch(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, mock, _ := sqlmock.New()
 	defer mockDB.Close()
 
@@ -119,7 +119,7 @@ func TestInsertBatch(t *testing.T) {
 }
 
 func TestGetAlbumsNoResults(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, mock, _ := sqlmock.New()
 	defer mockDB.Close()
 
@@ -139,7 +139,7 @@ func TestGetAlbumsNoResults(t *testing.T) {
 }
 
 func TestGetAlbumsError(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, mock, _ := sqlmock.New()
 	defer mockDB.Close()
 
@@ -157,7 +157,7 @@ func TestGetAlbumsError(t *testing.T) {
 }
 
 func TestInsertError(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, mock, _ := sqlmock.New()
 	defer mockDB.Close()
 
@@ -174,7 +174,7 @@ func TestInsertError(t *testing.T) {
 }
 
 func TestInsertBatchEmptySlice(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, _, _ := sqlmock.New()
 	defer mockDB.Close()
 
@@ -185,7 +185,7 @@ func TestInsertBatchEmptySlice(t *testing.T) {
 }
 
 func TestInsertBatchError(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, mock, _ := sqlmock.New()
 	defer mockDB.Close()
 
@@ -205,7 +205,7 @@ func TestInsertBatchError(t *testing.T) {
 }
 
 func TestGetAlbumsScanError(t *testing.T) {
-	config.Init()
+	config.Init(config.ConfigOptions{Path: "example/config", Name: "config", Type: "yaml"})
 	mockDB, mock, _ := sqlmock.New()
 	defer mockDB.Close()
 

--- a/example/features/albums/service_test.go
+++ b/example/features/albums/service_test.go
@@ -3,6 +3,7 @@ package albums
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -90,8 +91,11 @@ func TestGetAlbumsService(t *testing.T) {
 			Items: []Album{{ID: "2", Title: "Another Album", Artist: "Test Artist", Price: 14.99}},
 		}
 
+		marshalled, _ := json.Marshal(expectedAlbums)
+
 		mockCacher.Client.On("Get", ctx, "_albumsArtistFilter:Test Artist").Return("", cache.ErrCacheMiss).Once()
 		mockRepo.On("GetAlbums", ctx, artist).Return(expectedAlbums, nil).Once()
+		mockCacher.Client.On("Set", ctx, "_albumsArtistFilter:Test Artist", string(marshalled), time.Minute*10).Return(nil).Once()
 
 		albums, err := service.GetAlbums(ctx, GetAlbumsParams{
 			Artist: artist,
@@ -101,6 +105,24 @@ func TestGetAlbumsService(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedAlbums, albums)
+		mockCacher.Client.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("Repository error", func(t *testing.T) {
+		expectedErr := errors.New("db error")
+
+		mockCacher.Client.On("Get", ctx, "_albumsArtistFilter:Test Artist").Return("", cache.ErrCacheMiss).Once()
+		mockRepo.On("GetAlbums", ctx, artist).Return((*db.Paginated[Album])(nil), expectedErr).Once()
+
+		albums, err := service.GetAlbums(ctx, GetAlbumsParams{
+			Artist: artist,
+			Limit:  10,
+			Page:   0,
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, albums)
 		mockCacher.Client.AssertExpectations(t)
 		mockRepo.AssertExpectations(t)
 	})

--- a/testUtils/testUtils.go
+++ b/testUtils/testUtils.go
@@ -37,6 +37,10 @@ func (d *dummyAppTracer) CreateSpan(ctx context.Context, serviceName string) (co
 	return tracer.Start(ctx, serviceName)
 }
 
+func (d *dummyAppTracer) Shutdown(ctx context.Context) error {
+	return nil
+}
+
 func NewAppTracer() appTracer.AppTracer {
 	return &dummyAppTracer{}
 }


### PR DESCRIPTION
## Summary
- implement missing Shutdown method in `dummyAppTracer`
- fix Redis cache Get to return `ErrCacheMiss`
- adjust test configuration initialization
- expect cache set call in album service tests
- add repository error scenario test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6872f848069c8333b19e3c5e850d5afd