### PR TITLE
Add middleware extension hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ Middleware can be registered globally, for route groups, or for individual route
 
 When implementing new middleware, document it with a comment starting with `// @Middleware` so Swagger includes the description.
 
+#### Registering Custom Middleware
+
+Client projects can extend the request pipeline by registering their own middleware before starting the server. Middleware functions must follow the Gin handler signature:
+
+```go
+func(c *gin.Context)
+```
+
+Use `app.UseMiddleware` in `main.go` to add middleware that will run for every route after the built‑in middleware:
+
+```go
+srvMw := func(c *gin.Context) {
+    log.Printf("path: %s", c.Request.URL.Path)
+    c.Next()
+}
+
+app.UseMiddleware(srvMw)
+app.RunServer(app.ServerParams{Routes: registerRoutes, ConfigOptions: cfg})
+```
+
+Core middleware for tracing, context propagation, error handling and logging always runs first and cannot be replaced. Custom middleware executes next, followed by any route‑specific middleware configured within modules.
+
 ## Structure
 
 ```

--- a/app/custom_middleware.go
+++ b/app/custom_middleware.go
@@ -1,0 +1,13 @@
+package app
+
+import "github.com/gin-gonic/gin"
+
+// userMiddleware holds middleware functions registered by client applications.
+// These run after the built-in middleware defined in RunServer.
+var userMiddleware []gin.HandlerFunc
+
+// UseMiddleware registers a middleware to execute for every request.
+// It must be called before RunServer to take effect.
+func UseMiddleware(mw gin.HandlerFunc) {
+	userMiddleware = append(userMiddleware, mw)
+}

--- a/app/server.go
+++ b/app/server.go
@@ -104,6 +104,10 @@ func RunServer(ServerParams ServerParams) {
 	router.Use(middleware.ErrorHandler)
 	router.Use(middleware.JsonLogger())
 
+	for _, mw := range userMiddleware {
+		router.Use(mw)
+	}
+
 	var serverDependencies *dependencies.Dependencies
 	if ServerParams.Dependencies == nil {
 		serverDependencies = &dependencies.Dependencies{


### PR DESCRIPTION
## Summary
- allow registering custom middleware via `UseMiddleware`
- document middleware extension in README

## Testing
- `gofmt -s -w $(git ls-files '*.go')`
- `go vet ./...`
- `go test ./...` *(fails: Set(...) expectation mismatch in albums service tests)*
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68730312d708833382efd1a57ea2d17c