### PR TITLE
Fix vet failure and add missing test dependency

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,7 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=

--- a/pkg/clientContext/clientContext.go
+++ b/pkg/clientContext/clientContext.go
@@ -156,19 +156,6 @@ func AddDataStoreCall(ctx context.Context, call DataStoreCall) {
 	currentContext.DataStore = append(currentContext.DataStore, call)
 }
 
-func AddDatabaseCall(ctx context.Context, call DatabaseCall) {
-	currentContext := ctx.Value(ClientContextKey).(*ClientContext)
-	currentContext.Database = append(currentContext.Database, call)
-	dsCall := DataStoreCall{
-		ServiceTransaction: call.ServiceTransaction,
-		StoreType:          "db",
-		Operation:          call.Query,
-		ResponseTime:       call.ResponseTime,
-		Error:              call.Error,
-	}
-	currentContext.DataStore = append(currentContext.DataStore, dsCall)
-}
-
 func AddCacheCall(ctx context.Context, call CacheCall) {
 	currentContext := ctx.Value(ClientContextKey).(*ClientContext)
 	currentContext.Cache = append(currentContext.Cache, call)


### PR DESCRIPTION
## Summary
- remove unused AddDatabaseCall function from client context
- tidy dependencies for testify

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6876259f282c8333bf512f5589d1bdb0