### PR TITLE
Add automatic env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,15 @@ The application is configured using a YAML file located next to `main.go`. Edit 
 
    log:
      level: info
-     format: json
+   format: json
 
    Adjust the values according to your environment and requirements. The `maxOpenConns`, `maxIdleConns`, and `connMaxLifetime` settings control database connection pooling.
+
+You can override any configuration value with an environment variable by
+replacing dots in the key with underscores and uppercasing it. For example,
+`REDIS_HOST=cache.example.com` overrides `redis.host`. This is useful when
+deploying to containerized or cloud environments where settings are provided via
+environment variables.
 
 ## Features
 

--- a/docs/basic_server_setup.md
+++ b/docs/basic_server_setup.md
@@ -33,6 +33,10 @@ uptrace:
 
 Save the file as `config.yaml` in a directory accessible to your application.
 
+Any configuration value can be overridden using environment variables. Replace
+dots in the key with underscores and convert it to uppercase. For example,
+`REDIS_HOST=cache.example.com` overrides `redis.host`.
+
 ## 2. Implement `main.go`
 
 ```go

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jphilipstevens/web-service-gin/testUtils"
 	"github.com/jphilipstevens/web-service-gin/v2/pkg/config"
+	"github.com/jphilipstevens/web-service-gin/v2/testUtils"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/stretchr/testify/assert"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,9 +64,10 @@ func GetConfig() ConfigFile {
 	return configFile
 }
 
-// Config entries can be set in the config file or as environment variables.
-// When set as environment variables, the key should be in the format where the dot notation is replaced with an underscore.
-// For example, the key "redis.host" can be set as the environment variable "REDIS_HOST"
+// Config entries can be specified in the config file and overridden using
+// environment variables. To map an environment variable to a config field,
+// replace dots in the key with underscores and use uppercase letters. For
+// example, the key "redis.host" becomes "REDIS_HOST".
 func Init(opts ConfigOptions) error {
 	viper.SetConfigName(opts.Name)
 	viper.AddConfigPath(opts.Path)
@@ -76,6 +77,7 @@ func Init(opts ConfigOptions) error {
 	}
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
 
 	// Load configuration
 	err := viper.ReadInConfig()

--- a/pkg/middleware/logHandler_test.go
+++ b/pkg/middleware/logHandler_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jphilipstevens/web-service-gin/testUtils"
 	"github.com/jphilipstevens/web-service-gin/v2/pkg/clientContext"
+	"github.com/jphilipstevens/web-service-gin/v2/testUtils"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
## Summary
- enable environment variables to override YAML settings
- clarify env var usage in docs
- update tests for local utilities

## Testing
- `gofmt -s -w $(git ls-files '*.go')`
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68854ec525148333995f56bb5f16ef57