### PR TITLE
Centralize Uptrace DSN configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The application is configured using a YAML file located next to `main.go`. Edit 
      port: 8080
      timeout: 10s
 
+   uptrace:
+     dsn: http://project2_secret_token@localhost:14317/2
+
    database:
      host: localhost
      port: 5432

--- a/docs/basic_server_setup.md
+++ b/docs/basic_server_setup.md
@@ -11,6 +11,8 @@ app_name: demo
 server:
   host: 0.0.0.0
   port: 8080
+uptrace:
+  dsn: http://project2_secret_token@localhost:14317/2
 ```
 
 Save the file as `config.yaml` in a directory accessible to your application.

--- a/pkg/appTracer/appTracer.go
+++ b/pkg/appTracer/appTracer.go
@@ -5,7 +5,6 @@ package appTracer
 
 import (
 	"context"
-	"os"
 
 	"github.com/jphilipstevens/web-service-gin/v2/pkg/config"
 	"github.com/jphilipstevens/web-service-gin/v2/pkg/version"
@@ -28,7 +27,7 @@ type appTracerImpl struct {
 
 func initTracer(cfg config.Config) (trace.Tracer, error) {
 	uptrace.ConfigureOpentelemetry(
-		uptrace.WithDSN(os.Getenv("UPTRACE_DSN")),
+		uptrace.WithDSN(cfg.Uptrace.DSN),
 		uptrace.WithServiceName(cfg.AppName),
 		uptrace.WithServiceVersion(version.Version),
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,12 +13,18 @@ type ServerConfig struct {
 	Port int    `mapstructure:"port"`
 }
 
+// UptraceConfig holds the DSN used to connect to Uptrace for tracing.
+type UptraceConfig struct {
+	DSN string `mapstructure:"dsn"`
+}
+
 // Config represents the minimal application configuration required to start
 // the HTTP server. Additional configuration should be loaded separately by the
 // modules that need it.
 type Config struct {
-	AppName string       `mapstructure:"app_name"`
-	Server  ServerConfig `mapstructure:"server"`
+	AppName string        `mapstructure:"app_name"`
+	Server  ServerConfig  `mapstructure:"server"`
+	Uptrace UptraceConfig `mapstructure:"uptrace"`
 }
 
 // ConfigOptions defines how the configuration file is located and parsed.


### PR DESCRIPTION
## Summary
- introduce Uptrace configuration to replace `os.Getenv`
- update tracer setup to read DSN from configuration
- document Uptrace DSN usage in configuration examples

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6886e26ad6948333980cc050cc456f49