### PR TITLE
Expose middleware chain and graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The application is configured using a YAML file located next to `main.go`. Edit 
 
    uptrace:
      dsn: http://project2_secret_token@localhost:14317/2
+   enable_open_telemetry: true
 
    database:
      host: localhost
@@ -160,6 +161,21 @@ srv.Run()
 ```
 
 Core middleware for tracing, context propagation, error handling and logging always runs first and cannot be replaced. Custom middleware executes next, followed by any route‑specific middleware configured within modules.
+
+### Advanced server control
+
+For specialized scenarios you may want to bootstrap the HTTP server yourself. Use
+`ApplyMiddleware()` to attach all middleware, retrieve the router with `Router()`,
+and manage shutdown using `GracefulShutdown`:
+
+```go
+srv.ApplyMiddleware()
+s := &http.Server{Handler: srv.Router()}
+go s.ListenAndServe()
+
+// trigger shutdown somehow
+server.GracefulShutdown(s, time.Second*5)
+```
 
 ## Structure
 

--- a/docs/basic_server_setup.md
+++ b/docs/basic_server_setup.md
@@ -13,6 +13,7 @@ server:
   port: 8080
 uptrace:
   dsn: http://project2_secret_token@localhost:14317/2
+enable_open_telemetry: true
 ```
 
 Save the file as `config.yaml` in a directory accessible to your application.
@@ -89,3 +90,28 @@ go run main.go
 ```
 
 The server listens on the configured port and exposes `/ping` and `/hello` routes.
+
+## Advanced usage
+
+If you need finer control over the server lifecycle, you can apply middleware
+and start your own `http.Server` instance:
+
+```go
+srv := server.New(config.Get())
+
+srv.RegisterRoutes(registerRoutes)
+srv.ApplyMiddleware()
+
+httpSrv := &http.Server{Handler: srv.Router()}
+ln, _ := net.Listen("tcp", ":8080")
+go httpSrv.Serve(ln)
+
+go func() {
+    // trigger shutdown some other way
+    time.Sleep(time.Second)
+    p, _ := os.FindProcess(os.Getpid())
+    p.Signal(syscall.SIGTERM)
+}()
+
+server.GracefulShutdown(httpSrv, time.Second*5)
+```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	AppName string        `mapstructure:"app_name"`
 	Server  ServerConfig  `mapstructure:"server"`
 	Uptrace UptraceConfig `mapstructure:"uptrace"`
+	// EnableOpenTelemetry toggles insertion of tracing middleware.
+	// Defaults to true for backward compatibility.
+	EnableOpenTelemetry bool `mapstructure:"enable_open_telemetry"`
 }
 
 // ConfigOptions defines how the configuration file is located and parsed.
@@ -55,6 +58,9 @@ func Init(opts ConfigOptions) error {
 	if opts.Type != "" {
 		viper.SetConfigType(opts.Type)
 	}
+
+	// Preserve backward compatibility by defaulting tracing to enabled.
+	viper.SetDefault("enable_open_telemetry", true)
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -60,30 +60,82 @@ func (s *Server) UseFinal(mw ...gin.HandlerFunc) {
 	s.finalMiddleware = append(s.finalMiddleware, mw...)
 }
 
-// applyMiddleware attaches all registered middleware to the router in
-// the correct order. It only executes once even if called multiple times.
-func (s *Server) applyMiddleware() {
+// PreMiddleware returns the middleware registered with UseBefore.
+// The returned slice must not be modified by the caller.
+func (s *Server) PreMiddleware() []gin.HandlerFunc {
+	return append([]gin.HandlerFunc(nil), s.preMiddleware...)
+}
+
+// PostMiddleware returns the middleware registered with UseAfter.
+// The returned slice must not be modified by the caller.
+func (s *Server) PostMiddleware() []gin.HandlerFunc {
+	return append([]gin.HandlerFunc(nil), s.postMiddleware...)
+}
+
+// FinalMiddleware returns the middleware registered with UseFinal.
+// The returned slice must not be modified by the caller.
+func (s *Server) FinalMiddleware() []gin.HandlerFunc {
+	return append([]gin.HandlerFunc(nil), s.finalMiddleware...)
+}
+
+// BuiltInMiddleware returns the core middleware stack in the order it will be
+// applied. The slice must not be modified by the caller.
+func (s *Server) BuiltInMiddleware() []gin.HandlerFunc {
+	stack := []gin.HandlerFunc{
+		gin.Recovery(),
+	}
+	if s.config.EnableOpenTelemetry {
+		stack = append(stack, otelgin.Middleware(s.config.AppName))
+	}
+	stack = append(stack,
+		middleware.ClientContextMiddleware(),
+		middleware.TraceMiddleware(s.config.AppName),
+		middleware.ErrorHandler,
+		middleware.JsonLogger(),
+	)
+	return stack
+}
+
+// FullMiddlewareChain returns the ordered chain that will be applied to the router.
+// It consists of PreMiddleware, the built-in stack, PostMiddleware and FinalMiddleware.
+// The returned slice must not be modified by the caller.
+func (s *Server) FullMiddlewareChain() []gin.HandlerFunc {
+	chain := make([]gin.HandlerFunc, 0,
+		len(s.preMiddleware)+len(s.postMiddleware)+len(s.finalMiddleware)+6)
+	chain = append(chain, s.preMiddleware...)
+	chain = append(chain, s.BuiltInMiddleware()...)
+	chain = append(chain, s.postMiddleware...)
+	chain = append(chain, s.finalMiddleware...)
+	return chain
+}
+
+// Router exposes the underlying Gin engine for advanced usage.
+// Handlers must call ApplyMiddleware before serving requests.
+func (s *Server) Router() *gin.Engine {
+	return s.router
+}
+
+// ApplyMiddleware attaches registered middleware to the router in
+// the correct order. It is idempotent so repeated calls have no effect.
+func (s *Server) ApplyMiddleware() {
 	if s.middlewareApplied {
 		return
 	}
 
-	if len(s.preMiddleware) > 0 {
-		s.router.Use(s.preMiddleware...)
+	for _, mw := range s.preMiddleware {
+		s.router.Use(mw)
 	}
 
-	s.router.Use(gin.Recovery())
-	s.router.Use(otelgin.Middleware(s.config.AppName))
-	s.router.Use(middleware.ClientContextMiddleware())
-	s.router.Use(middleware.TraceMiddleware(s.config.AppName))
-	s.router.Use(middleware.ErrorHandler)
-	s.router.Use(middleware.JsonLogger())
-
-	if len(s.postMiddleware) > 0 {
-		s.router.Use(s.postMiddleware...)
+	for _, mw := range s.BuiltInMiddleware() {
+		s.router.Use(mw)
 	}
 
-	if len(s.finalMiddleware) > 0 {
-		s.router.Use(s.finalMiddleware...)
+	for _, mw := range s.postMiddleware {
+		s.router.Use(mw)
+	}
+
+	for _, mw := range s.finalMiddleware {
+		s.router.Use(mw)
 	}
 
 	s.middlewareApplied = true
@@ -91,14 +143,14 @@ func (s *Server) applyMiddleware() {
 
 // RegisterRoutes allows modules to add routes to the server.
 func (s *Server) RegisterRoutes(fn func(r *gin.Engine)) {
-	s.applyMiddleware()
+	s.ApplyMiddleware()
 	fn(s.router)
 }
 
 // Run starts the HTTP server, applies middleware in the correct order, and
 // waits for a shutdown signal.
 func (s *Server) Run() error {
-	s.applyMiddleware()
+	s.ApplyMiddleware()
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf("%s:%d", s.config.Server.Host, s.config.Server.Port),
@@ -113,15 +165,21 @@ func (s *Server) Run() error {
 		}
 	}()
 
+	return GracefulShutdown(srv, gracefulShutdownTimeout)
+}
+
+// GracefulShutdown blocks until an interrupt signal is received and then attempts
+// to shut down the provided server within the given timeout.
+func GracefulShutdown(srv *http.Server, timeout time.Duration) error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 
-	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		logrus.Fatalf("server shutdown failed: %v", err)
+		return fmt.Errorf("server shutdown failed: %w", err)
 	}
 
 	logrus.Info("server exited properly")

--- a/pkg/server_test.go
+++ b/pkg/server_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/jphilipstevens/web-service-gin/v2/pkg/config"
+)
+
+func TestMiddlewareSlicesAreImmutable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.Config{AppName: "test", EnableOpenTelemetry: false}
+	s := New(cfg)
+
+	m1 := func(c *gin.Context) {}
+	s.UseBefore(m1)
+
+	got := s.PreMiddleware()
+	got = append(got, func(c *gin.Context) {})
+
+	assert.Equal(t, 1, len(s.PreMiddleware()))
+}
+
+func TestBuiltInMiddlewareToggle(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.Config{AppName: "test", EnableOpenTelemetry: false}
+	s := New(cfg)
+
+	assert.Equal(t, 5, len(s.BuiltInMiddleware()))
+
+	cfg.EnableOpenTelemetry = true
+	s = New(cfg)
+	assert.Equal(t, 6, len(s.BuiltInMiddleware()))
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := config.Config{AppName: "test", EnableOpenTelemetry: false}
+	s := New(cfg)
+	s.RegisterRoutes(func(r *gin.Engine) {
+		r.GET("/ping", func(c *gin.Context) {})
+	})
+	s.ApplyMiddleware()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+
+	httpSrv := &http.Server{Handler: s.Router()}
+	go httpSrv.Serve(ln)
+
+	done := make(chan error)
+	go func() { done <- GracefulShutdown(httpSrv, time.Millisecond) }()
+
+	time.Sleep(10 * time.Millisecond)
+	p, _ := os.FindProcess(os.Getpid())
+	p.Signal(syscall.SIGTERM)
+
+	assert.NoError(t, <-done)
+}


### PR DESCRIPTION
## Summary
- expose middleware stacks and router for advanced control
- allow disabling OpenTelemetry via config
- add ApplyMiddleware and GracefulShutdown helpers
- document advanced usage
- add tests for new behavior

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68877688f9c8833399b8365d25809e3b