### PR TITLE
Enable trace-aware logging

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,10 @@
+# Logging with Trace IDs
+
+- Use `logutils.WithTrace(ctx)` for all logs inside a request.
+- Example:
+
+```go
+logutils.WithTrace(ctx).Info("Election started")
+```
+
+This ensures traceability across the distributed system.

--- a/pkg/logutils/logutils.go
+++ b/pkg/logutils/logutils.go
@@ -1,0 +1,20 @@
+package logutils
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// WithTrace returns a logrus Entry with traceId and spanId fields attached.
+// Always use this for logging inside a request context.
+func WithTrace(ctx context.Context) *logrus.Entry {
+	sc := trace.SpanContextFromContext(ctx)
+	traceId := sc.TraceID().String()
+	spanId := sc.SpanID().String()
+	return logrus.WithFields(logrus.Fields{
+		"traceId": traceId,
+		"spanId":  spanId,
+	})
+}

--- a/pkg/middleware/logHandler.go
+++ b/pkg/middleware/logHandler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jphilipstevens/web-service-gin/v2/pkg/clientContext"
+	"github.com/jphilipstevens/web-service-gin/v2/pkg/logutils"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -22,7 +23,7 @@ func JsonLogger() gin.HandlerFunc {
 		if c.Request.Body != nil {
 			body, err := io.ReadAll(c.Request.Body)
 			if err != nil {
-				logrus.WithError(err).Warn("Failed to read request body")
+				logutils.WithTrace(c.Request.Context()).WithError(err).Warn("Failed to read request body")
 			} else {
 				requestBody = body
 			}
@@ -72,6 +73,6 @@ func JsonLogger() gin.HandlerFunc {
 			fields["requestBody"] = string(requestBody)
 		}
 
-		logrus.WithFields(fields).Log(level, "Request logged")
+		logutils.WithTrace(c.Request.Context()).WithFields(fields).Log(level, "Request logged")
 	}
 }


### PR DESCRIPTION
## Summary
- add log helper package to attach trace info
- log request errors and completions with trace data
- document logging with trace IDs

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a070309548333ac9ac224b621de35