### PR TITLE
docs: explain how to add gRPC and GraphQL servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,27 @@ go s.ListenAndServe()
 server.GracefulShutdown(s, time.Second*5)
 ```
 
+### Extending beyond HTTP
+
+The HTTP server exposes composable building blocks so you can run additional
+protocols alongside Gin. For example, start a gRPC or GraphQL server in the same
+process and manage their lifecycles together:
+
+```go
+go srv.Run() // existing HTTP service
+
+grpcSrv := grpc.NewServer()
+go grpcSrv.Serve(lis)
+
+// shutdown logic
+server.GracefulShutdown(httpSrv, time.Second*5)
+grpcSrv.GracefulStop()
+```
+
+The template keeps middleware, configuration and shutdown utilities decoupled,
+making it straightforward to integrate other protocols without altering the core
+modules.
+
 ## Structure
 
 ```

--- a/docs/basic_server_setup.md
+++ b/docs/basic_server_setup.md
@@ -115,3 +115,23 @@ go func() {
 
 server.GracefulShutdown(httpSrv, time.Second*5)
 ```
+
+## Adding gRPC or GraphQL servers
+
+The modular design allows you to start other protocols alongside the HTTP
+server. Initialize your gRPC or GraphQL handler, then run them concurrently with
+the Gin server:
+
+```go
+go httpSrv.Serve(ln) // existing HTTP service
+
+grpcSrv := grpc.NewServer()
+go grpcSrv.Serve(grpcLn)
+
+// on shutdown
+server.GracefulShutdown(httpSrv, time.Second*5)
+grpcSrv.GracefulStop()
+```
+
+The core packages remain agnostic to additional transports, so you can compose
+multiple servers without modifying the template itself.


### PR DESCRIPTION
## Summary
- document adding other protocols alongside Gin

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a1ae0a3808333b5440097a9ef747b